### PR TITLE
feat: support massif v1 peak stack (fixed) allocation

### DIFF
--- a/diag.go
+++ b/diag.go
@@ -56,7 +56,13 @@ func NewDiagCmd() *cli.Command {
 				massifIndex = uint32(massifs.MassifIndexFromMMRIndex(cmd.MassifFmt.MassifHeight, mmrIndex))
 			}
 			fmt.Printf("%8d peak-stack-len\n", massifs.PeakStackLen(uint64(massifIndex)))
-			logStart := massifs.PeakStackEnd(uint64(massifIndex), cmd.MassifFmt.MassifHeight)
+			var logStart uint64
+			switch massif.Start.Version {
+			case 1:
+				logStart = massifs.PeakStackEnd(cmd.MassifFmt.MassifHeight)
+			case 0:
+				logStart = massifs.PeakStackEndV0(uint64(massifIndex), cmd.MassifFmt.MassifHeight)
+			}
 			fmt.Printf("%8d tree-start\n", logStart)
 			fmt.Printf("%8d massif\n", massifIndex)
 			if mmrIndex > 0 {

--- a/massifs.go
+++ b/massifs.go
@@ -106,7 +106,10 @@ to produce the desired information computationaly produce
 				// massif.
 				peakStackIndices = PeakStack(height, firstMMRIndex)
 				peakStackStart := massifs.PeakStackStart(height)
-				logStart := massifs.PeakStackEnd(mi, height)
+
+				// Note: printing the table is specifically about the packed
+				// accumulator form, so we are always 'V0' here.
+				logStart := massifs.PeakStackEndV0(mi, height)
 
 				tableFmt := "|% 8d|% 8d|% 8d|% 8d|% 8d|% 8d|% 8d| [%s]"
 				plainFmt := "% 8d% 8d% 8d% 8d% 8d% 8d% 8d [%s]"


### PR DESCRIPTION
accomodate v1 massif's which pre-allocate space for a max tree heights worth of accumulator nodes. this enables node & leaf counts to be computed directly from the byte size of the massif